### PR TITLE
Fix for loading hwcrypto.js with Chrome in iframed window

### DIFF
--- a/demo/iframe-sign.html
+++ b/demo/iframe-sign.html
@@ -1,0 +1,9 @@
+<html>
+<head>
+</head>
+<body>
+
+<!--<iframe src="https://open-eid.github.io/hwcrypto.js/sign.html" height="500" width="600"/>-->
+<iframe src="hwcrypto-test/sign.html" height="500" width="600"/>
+</body>
+</html>

--- a/demo/iframe-sign.html
+++ b/demo/iframe-sign.html
@@ -2,8 +2,7 @@
 <head>
 </head>
 <body>
-
-<!--<iframe src="https://open-eid.github.io/hwcrypto.js/sign.html" height="500" width="600"/>-->
-<iframe src="hwcrypto-test/sign.html" height="500" width="600"/>
+<p>This will load sign.html to an iFrame. With Google Chrome you would get "no_implementation" if not for a fixed hwcrypto.js</p>
+<iframe src="sign.html" height="500" width="600"/>
 </body>
 </html>

--- a/src/hwcrypto.js
+++ b/src/hwcrypto.js
@@ -14,7 +14,30 @@ var hwcrypto = (function hwcrypto() {
     }
     // Checks if a function is present (used for Chrome)
     function hasExtensionFor(cls) {
-        return typeof window[cls] === 'function';
+        if (typeof window[cls] === "function") 
+        {
+            return true;
+        }
+        else if (typeof window.top[cls] === "function")
+        {
+            return true;
+        }
+        else
+        {
+            return false;
+        }
+    }
+    function getExtensionFor(cls) 
+    {
+        if (typeof window[cls] === "function") 
+        {
+            return new window[cls]();
+        }
+        else if (typeof window.top[cls] === "function")
+        {
+            return new window.top[cls]();
+        }
+        return null;
     }
 
     function _hex2array(str) {
@@ -178,8 +201,7 @@ var hwcrypto = (function hwcrypto() {
                 if (!hasExtensionFor(digidoc_chrome)) {
                     return resolve(false);
                 }
-                // FIXME: remove this from content script!
-                p = new window[digidoc_chrome]();
+                p = getExtensionFor(digidoc_chrome);
                 if (p) {
                     resolve(true);
                 } else {

--- a/src/hwcrypto.js
+++ b/src/hwcrypto.js
@@ -14,30 +14,24 @@ var hwcrypto = (function hwcrypto() {
     }
     // Checks if a function is present (used for Chrome)
     function hasExtensionFor(cls) {
-        if (typeof window[cls] === "function") 
-        {
+        if (typeof window[cls] === 'function') {
             return true;
         }
-        else if (typeof window.top[cls] === "function")
-        {
+        else if (typeof window.top[cls] === 'function') {
             return true;
         }
-        else
-        {
+        else {
             return false;
         }
     }
     function getExtensionFor(cls) 
     {
-        if (typeof window[cls] === "function") 
-        {
+        if (typeof window[cls] === 'function') {
             return new window[cls]();
         }
-        else if (typeof window.top[cls] === "function")
-        {
+        else if (typeof window.top[cls] === 'function') {
             return new window.top[cls]();
         }
-        return null;
     }
 
     function _hex2array(str) {


### PR DESCRIPTION
Hwcrypto.js fails to load with Chrome when hwcrypto.js is loaded to iframe (not top-most document). For test see iframe-sign.html, there we get "no_implementation" with Chrome. I've included fix for hwcrypto.js that fixes this.
