### PR TITLE
Use grunt and bower from project's node_modules directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 default: bower_components
-	grunt
+	npx grunt
 
 node_modules:
 	npm install
 
 bower_components: node_modules
-	bower install
+	npx bower install
 
 publish: bower_components
 	grunt publish


### PR DESCRIPTION
Running `npm install` will insall grunt and bower locally, but the Makefile expects grunt and bower to also be installed globally.
This can cause a version mismatch between the version defined in package.json and the version installed globally by a developer, which in turn can cause differences in the build outcome.

This change adds the `npx` command which is bundled with npm 5.2.0 and later, which in turn is bundled with Node.js 8.2.0 and later versions. The `npx` command executes scripts from the project's local `node_modules/.bin` directory.